### PR TITLE
Improve haircut suggestion layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
   <h1 class="text-2xl font-bold mb-4">Haircut Suggestions</h1>
   <button id="showHaircutsBtn" class="bg-blue-500 text-white px-4 py-2 rounded">Show Haircuts</button>
 
-  <div id="haircutSuggestions" class="mt-4 space-y-2"></div>
+  <div id="haircutSuggestions" class="mt-4 space-y-3 mx-auto max-w-md"></div>
 
-  <div id="barberCard" class="mt-6 border border-gray-300 p-4 shadow hidden">
+  <div id="barberCard" class="mt-6 border border-gray-300 p-4 shadow bg-white rounded max-w-md mx-auto hidden">
     <h2 class="text-xl font-semibold mb-2">Barber Card</h2>
     <div id="barberCardContent" class="space-y-2"></div>
   </div>

--- a/main.js
+++ b/main.js
@@ -6,16 +6,17 @@ const printBtn = document.getElementById('printBarberCardBtn');
 
 showBtn.addEventListener('click', () => {
   const suggestions = [
-    { name: 'Crew Cut', img: 'https://via.placeholder.com/150' },
-    { name: 'Fade', img: 'https://via.placeholder.com/150' },
-    { name: 'Pompadour', img: 'https://via.placeholder.com/150' }
+    { name: 'Crew Cut' },
+    { name: 'Fade' },
+    { name: 'Pompadour' }
   ];
 
   suggestionsContainer.innerHTML = '';
   suggestions.forEach(s => {
     const div = document.createElement('div');
-    div.className = 'flex items-center space-x-2';
-    div.innerHTML = `<img src="${s.img}" alt="${s.name}" class="w-16 h-16 object-cover rounded"><span>${s.name}</span>`;
+    div.className = 'flex items-center gap-4 p-3 rounded shadow bg-white';
+    const imgUrl = `https://via.placeholder.com/100?text=${encodeURIComponent(s.name)}`;
+    div.innerHTML = `<img src="${imgUrl}" alt="${s.name}" class="w-16 h-16 object-cover rounded"><span>${s.name}</span>`;
     suggestionsContainer.appendChild(div);
   });
 
@@ -34,7 +35,7 @@ printBtn.addEventListener('click', () => {
         <script src="https://cdn.tailwindcss.com"></script>
       </head>
       <body class="p-4">
-        <div class="border border-gray-300 p-4 shadow">
+        <div class="border border-gray-300 p-4 shadow bg-white rounded max-w-md mx-auto">
           ${card}
         </div>
       </body>


### PR DESCRIPTION
## Summary
- center suggestions in a `max-w-md` container
- make individual suggestions and printed cards appear as white cards
- use placeholder images with haircut name text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685580e1d008832e8aa98aa519ef518c