### PR TITLE
Implement Tailwind card styles for haircut list

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
   <h1 class="text-2xl font-bold mb-4">Haircut Suggestions</h1>
   <button id="showHaircutsBtn" class="bg-blue-500 text-white px-4 py-2 rounded">Show Haircuts</button>
 
-  <div id="haircutSuggestions" class="mt-4 space-y-2"></div>
+  <ul id="haircutSuggestions" class="mt-4"></ul>
 
   <div id="barberCard" class="mt-6 border border-gray-300 p-4 shadow hidden">
     <h2 class="text-xl font-semibold mb-2">Barber Card</h2>
-    <div id="barberCardContent" class="space-y-2"></div>
+    <ul id="barberCardContent" class="space-y-2"></ul>
   </div>
   <button id="printBarberCardBtn" class="mt-2 bg-green-500 text-white px-3 py-1 rounded hidden">Print Card</button>
 

--- a/main.js
+++ b/main.js
@@ -13,10 +13,11 @@ showBtn.addEventListener('click', () => {
 
   suggestionsContainer.innerHTML = '';
   suggestions.forEach(s => {
-    const div = document.createElement('div');
-    div.className = 'flex items-center space-x-2';
-    div.innerHTML = `<img src="${s.img}" alt="${s.name}" class="w-16 h-16 object-cover rounded"><span>${s.name}</span>`;
-    suggestionsContainer.appendChild(div);
+    const li = document.createElement('li');
+    li.className = 'flex items-center gap-4 border rounded p-3 mb-2 bg-white shadow';
+    li.innerHTML = `<img src="${s.img}" alt="${s.name}" class="w-20 h-20 object-cover rounded" />` +
+      `<span class="text-lg font-medium">${s.name}</span>`;
+    suggestionsContainer.appendChild(li);
   });
 
   barberCardContent.innerHTML = suggestionsContainer.innerHTML;


### PR DESCRIPTION
## Summary
- use `<ul>` containers for haircut suggestions and barber card contents
- show each suggestion in a card-style `<li>` using Tailwind classes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68557cb3a600832e9a7162cc3b718881